### PR TITLE
Added allow capital letter in dependency name

### DIFF
--- a/pyhelm3/models.py
+++ b/pyhelm3/models.py
@@ -39,7 +39,7 @@ NonEmptyString = constr(min_length = 1)
 
 
 #: Type for a name (chart or release)
-Name = constr(pattern = r"^[a-z0-9-]+$")
+Name = constr(pattern = r"^[a-zA-Z0-9-]+$")
 
 
 #: Type for a SemVer version


### PR DESCRIPTION
I am deploying the Authentik helm chart with pyhelm3 and I receive an error I think is not okay.

Inside the [values.yaml](https://github.com/goauthentik/helm/blob/main/charts/authentik/values.yaml) file there is the following block:
```
serviceAccount:
  # -- Create service account. Needed for managed outposts
  create: true
  # -- additional service account annotations
  annotations: {}
  serviceAccountSecret:
    # As we use the authentik-remote-cluster chart as subchart, and that chart
    # creates a service account secret by default which we don't need here,
    # disable its creation
    enabled: false
  fullnameOverride: authentik
```
The dependency name `serviceAccount` does not validate with the rule `r"^[a-z0-9-]+$"` from `models.py:42` because it contains a capital letter.
However the chart deploys perfectly fine with `helm3` with no issue on the capital letter for the dependency name, I think the correct rule should be `r"^[a-zA-Z0-9-]+$"`which corrects the error I'm facing