### PR TITLE
Allow underscores in names

### DIFF
--- a/pyhelm3/models.py
+++ b/pyhelm3/models.py
@@ -43,7 +43,7 @@ NonEmptyString = constr(min_length = 1)
 
 
 #: Type for a name (chart or release)
-Name = constr(pattern = r"^[a-z0-9-]+$")
+Name = constr(pattern = r"^[a-z0-9_-]+$")
 
 
 #: Type for a SemVer version
@@ -273,7 +273,7 @@ class Release(ModelWithCommand):
     )
     namespace: Name = Field(
         ...,
-        description = "The namespace of the release." 
+        description = "The namespace of the release."
     )
 
     async def current_revision(self) -> ReleaseRevisionType:
@@ -642,7 +642,7 @@ class ReleaseRevision(ModelWithCommand):
             )
             self.chart_metadata_ = ChartMetadata(**metadata)
         return self.chart_metadata_
-    
+
     async def hooks(self) -> t.Iterable[Hook]:
         """
         Returns the hooks that were executed as part of this revision.

--- a/pyhelm3/models.py
+++ b/pyhelm3/models.py
@@ -43,7 +43,10 @@ NonEmptyString = constr(min_length = 1)
 
 
 #: Type for a name (chart or release)
-Name = constr(pattern = r"^[a-z0-9_-]+$")
+Name = constr(pattern = r"^[a-z0-9-]+$")
+
+#: Type for a dependency name
+DependencyNameOrAlias = constr(pattern = r"^[a-z0-9_-]+$")
 
 
 #: Type for a SemVer version
@@ -71,9 +74,9 @@ class ChartDependency(BaseModel):
     """
     Model for a chart dependency.
     """
-    name: Name = Field(
+    name: DependencyNameOrAlias = Field(
         ...,
-        description = "The name of the chart."
+        description = "The name of the chart (or alias, in case of an already-installed dependency)."
     )
     version: NonEmptyString = Field(
         ...,


### PR DESCRIPTION
As the name implies, this adds support for underscore in various names. I'm not entirely sure why this model is so strict to begin with (the [Go SDK](https://github.com/helm/helm/blob/main/pkg/chart/v2/metadata.go#L93) only strips non-printable characters and leading/tailing whitespace), but I can attest that underscores work perfectly fine in e.g. chart dependency names, which is where I ran into this :-)
