### PR TITLE
Use distinct type for dependencies' aliases & names

### DIFF
--- a/pyhelm3/models.py
+++ b/pyhelm3/models.py
@@ -45,6 +45,11 @@ NonEmptyString = constr(min_length=1)
 Name = constr(pattern=r"^[a-z0-9-]+$")
 
 
+#: Type for a dependency alias or name
+#: which gets populated from alias after installation
+DependencyAliasOrName = NonEmptyString
+
+
 #: Type for a SemVer version
 SemVerVersion = constr(
     pattern=r"^v?\d+\.\d+\.\d+(-[a-zA-Z0-9\.\-]+)?(\+[a-zA-Z0-9\.\-]+)?$"
@@ -73,7 +78,7 @@ class ChartDependency(BaseModel):
     Model for a chart dependency.
     """
 
-    name: Name = Field(..., description="The name of the chart.")
+    name: DependencyAliasOrName = Field(..., description="The name of the chart.")
     version: NonEmptyString = Field(
         ..., description="The version of the chart. Can be a SemVer range."
     )
@@ -95,7 +100,7 @@ class ChartDependency(BaseModel):
             "Each item can be a string or pair of child/parent sublist items."
         ),
     )
-    alias: t.Optional[NonEmptyString] = Field(
+    alias: t.Optional[DependencyAliasOrName] = Field(
         None, description="Alias to be used for the chart."
     )
 

--- a/pyhelm3/models.py
+++ b/pyhelm3/models.py
@@ -46,6 +46,10 @@ NonEmptyString = constr(min_length = 1)
 Name = constr(pattern = r"^[a-z0-9-]+$")
 
 
+#: Type for a dependency alias or name (which gets populated from alias after installation)
+DependencyAliasOrName = NonEmptyString
+
+
 #: Type for a SemVer version
 SemVerVersion = constr(pattern = r"^v?\d+\.\d+\.\d+(-[a-zA-Z0-9\.\-]+)?(\+[a-zA-Z0-9\.\-]+)?$")
 
@@ -71,7 +75,7 @@ class ChartDependency(BaseModel):
     """
     Model for a chart dependency.
     """
-    name: Name = Field(
+    name: DependencyAliasOrName = Field(
         ...,
         description = "The name of the chart."
     )
@@ -99,7 +103,7 @@ class ChartDependency(BaseModel):
             "Each item can be a string or pair of child/parent sublist items."
         )
     )
-    alias: t.Optional[NonEmptyString] = Field(
+    alias: t.Optional[DependencyAliasOrName] = Field(
         None,
         description = "Alias to be used for the chart."
     )


### PR DESCRIPTION
When `helm install`/`helm upgrade` the name of dependencies returned with `--output json` is replaced by their alias (if any).

e.g. https://github.com/goauthentik/helm/blob/authentik-2025.10.0/charts/authentik/Chart.yaml#L40-L44
```yaml
  - name: authentik-remote-cluster
    repository: https://charts.goauthentik.io
    version: 2.1.0
    condition: serviceAccount.create
    alias: serviceAccount
```

Results in:
```json
$ helm upgrade -i authentik --output json oci://ghcr.io/goauthentik/helm-charts/authentik:2025.10.0 | jq '.chart.metadata.dependencies[0]'
Pulled: ghcr.io/goauthentik/helm-charts/authentik:2025.10.0
Digest: sha256:8b617e3bcb9f9988fe0be8428cf1f78489236e1a73385cfdd692517a0d269435
{
  "name": "serviceAccount",
  "version": "2.1.0",
  "repository": "https://charts.goauthentik.io",
  "condition": "serviceAccount.create",
  "enabled": true,
  "alias": "serviceAccount"
}
```

`ChartDependency.alias` allows an arbitrary non-empty string to be used, so `ChartDependency.name` needs to match this. #9 attempted to resolve this via changing the `Name` type, this PR just loosens the restrictions on `dependencies[].{name,alias}`.

Alternatively this PR could be taken further and impose the restrictions from #9 to just `dependencies[].{name,alias}`.

Edit: whops I forgot #31 exists. This PR would solve the issue #31 is having, but #31 would need slightly looser restrictions (allowing `A-Z` too) to solve the problem I'm having with Authentik