### PR TITLE
support semver 3.x

### DIFF
--- a/pyhelm3/command.py
+++ b/pyhelm3/command.py
@@ -1042,4 +1042,4 @@ class Command:
             shell_formatted_command, capture_output=True, check=True, shell=True
         )
         version_str = proc.stdout.decode().removeprefix("v")
-        return semver.parse_version_info(version_str)
+        return semver.VersionInfo.parse(version_str)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.10"
 dependencies = [
     "pyyaml >= 6.0.2,<7",
     "pydantic >= 2.10.6,<3",
-    "semver >= 2.9.1,<3"
+    "semver >= 2.9.1,<4"
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -333,7 +333,7 @@ dev = [
 requires-dist = [
     { name = "pydantic", specifier = ">=2.10.6,<3" },
     { name = "pyyaml", specifier = ">=6.0.2,<7" },
-    { name = "semver", specifier = ">=2.9.1,<3" },
+    { name = "semver", specifier = ">=2.9.1,<4" },
 ]
 
 [package.metadata.requires-dev]
@@ -505,11 +505,11 @@ wheels = [
 
 [[package]]
 name = "semver"
-version = "2.13.0"
+version = "3.0.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/31/a9/b61190916030ee9af83de342e101f192bbb436c59be20a4cb0cdb7256ece/semver-2.13.0.tar.gz", hash = "sha256:fa0fe2722ee1c3f57eac478820c3a5ae2f624af8264cbdf9000c980ff7f75e3f", size = 45816, upload-time = "2020-10-20T20:16:54.454Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/d1/d3159231aec234a59dd7d601e9dd9fe96f3afff15efd33c1070019b26132/semver-3.0.4.tar.gz", hash = "sha256:afc7d8c584a5ed0a11033af086e8af226a9c0b206f313e0301f8dd7b6b589602", size = 269730, upload-time = "2025-01-24T13:19:27.617Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/70/b84f9944a03964a88031ef6ac219b6c91e8ba2f373362329d8770ef36f02/semver-2.13.0-py2.py3-none-any.whl", hash = "sha256:ced8b23dceb22134307c1b8abfa523da14198793d9787ac838e70e29e77458d4", size = 12901, upload-time = "2020-10-20T20:16:52.583Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/24/4d91e05817e92e3a61c8a21e08fd0f390f5301f1c448b137c57c4bc6e543/semver-3.0.4-py3-none-any.whl", hash = "sha256:9c824d87ba7f7ab4a1890799cec8596f15c1241cb473404ea1cb0c55e4b04746", size = 17912, upload-time = "2025-01-24T13:19:24.949Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
PR #41 explicitly restricts semver to versions >=2.9.1,<3 while latest release is 3.0.4

this PR extends supported range to <4
and replaces one use of the deprecated `semver.parse_version_info` with `semver.VersionInfo.parse` which is used by the rest of this project.