### PR TITLE
Changed type for chart dependency name and alias

### DIFF
--- a/pyhelm3/models.py
+++ b/pyhelm3/models.py
@@ -46,6 +46,10 @@ NonEmptyString = constr(min_length=1)
 Name = constr(pattern=r"^[a-z0-9-]+$")
 
 
+#: Type for a chart dependency name/alias
+DependencyNameOrAlias = constr(pattern=r"^[a-zA-Z0-9_-]+$")
+
+
 #: Type for a SemVer version
 SemVerVersion = constr(
     pattern=r"^v?\d+\.\d+\.\d+(-[a-zA-Z0-9\.\-]+)?(\+[a-zA-Z0-9\.\-]+)?$"
@@ -79,7 +83,7 @@ class ChartDependency(BaseModel):
     Model for a chart dependency.
     """
 
-    name: Name = Field(..., description="The name of the chart.")
+    name: DependencyNameOrAlias = Field(..., description="The name of the chart.")
     version: NonEmptyString = Field(
         ..., description="The version of the chart. Can be a SemVer range."
     )
@@ -101,7 +105,7 @@ class ChartDependency(BaseModel):
             "Each item can be a string or pair of child/parent sublist items."
         ),
     )
-    alias: t.Optional[NonEmptyString] = Field(
+    alias: t.Optional[DependencyNameOrAlias] = Field(
         None, description="Alias to be used for the chart."
     )
 


### PR DESCRIPTION
This change solves the issues in #31 and #37 by allowing both name and alias in chart dependency to have underscores and capital letters, whilst still enforcing the DNS conventions for release names.

- A new compound type `DependencyNameOrAlias` is added, enforcing regex rules from here https://github.com/helm/helm/blob/e29e06e97d1a8cbf0f7c5c6e53a04e9369db0866/pkg/chart/v2/chart.go#L34
- The type of both `name` and `alias` in the `ChartDependency` class is set to `DependencyNameOrAlias`, fixing the issue of aliases replacing names causing a type clash
- The type of `name` in the `Release` class is unchanged, enforcing DNS-compliant regex
- The type of `name` in the `ChartMetadata` class is unchanged, would this cause an issue? Not sure if it is also affected by alias. Edit: metadata is unaffected, so this is fine.